### PR TITLE
Fix for Create React App 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "type": "module",
     "sideEffects": false,
     "main": "lib/cjs/index.js",
-    "module": "lib/esm/index.mjs",
+    "module": "lib/esm/index.js",
     "types": "lib/types/index.d.ts",
     "exports": {
-        "import": "./lib/esm/index.mjs",
+        "import": "./lib/esm/index.js",
         "require": "./lib/cjs/index.js"
     },
     "files": [
@@ -23,7 +23,7 @@
     },
     "scripts": {
         "clean": "shx rm -rf lib/*",
-        "build": "yarn clean && tsc -p tsconfig.json && tsc-esm -p tsconfig.json && tsc -p tsconfig.cjs.json",
+        "build": "yarn clean && tsc -p tsconfig.json && tsc -p tsconfig.cjs.json",
         "postbuild": "echo '{\"type\":\"commonjs\"}' | npx json > lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > lib/esm/package.json"
     },
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@strike-protocols/solana-wallet-adapter",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "author": "Strike Developers <developers@strikeprotocols.com>",
     "repository": "https://github.com/StrikeProtocols/strike-solana-wallet-adapter",
     "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export * from './strikewallet';
+export * from './strikewallet.js';


### PR DESCRIPTION
CRA4 can't import .mjs files. This PR fixes the build nonbreakingly so that ESM and CJS builds both export .js files. Key to this is making sure all internal imports (there's only one) explicitly declare `.js` file extensions for imports.